### PR TITLE
Configuration options and handling for canBeCached handling in Form class

### DIFF
--- a/src/Controllers/ChimpleController.php
+++ b/src/Controllers/ChimpleController.php
@@ -153,6 +153,10 @@ class ChimpleController extends PageController
             $form->setFormMethod("GET", false);
         }
 
+        if($form->hasMethod('enableSpamProtection')) {
+            $form->enableSpamProtection();
+        }
+
         // allow extensions to manipulate the form
         $form->extend('updateChimpleSubscribeForm');
 


### PR DESCRIPTION
## Changes

Provide options to work around disableCache() being called when a form meets the criteria defined in canBeCached()

+ Specify the form action to be GET (use with XHR submissions, which are done by POST)
+ Provide configuration option to disable the security token ( use with enableSpamProtection() )
+ Use enableSpamProtection if a spam protector is available (as defined by project configuration)

By default, security token is enabled and the form is set to POST.

## References

+ disableCache() ... https://github.com/silverstripe/silverstripe-framework/blob/4/src/Forms/Form.php#L1599
+ https://github.com/silverstripe/silverstripe-framework/blob/4/src/Forms/Form.php#L1864

