### PR TITLE
Patch (update) subscriber if they exist at Mailchimp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,113 +1,43 @@
 # Chimple - Simple Mailchimp handling in Silverstripe
 
-This module allows you to manage list subscriptions from a silverstripe app/website.
+This module allows you to create and update Mailchimp list subscriptions via a Silverstripe app/website.
 
-It provides:
+## Developers
+
+It supports:
 
 + a subscription controller
-+ multiple configuration records for setting multiple list/audience configurations
++ multiple configuration records for setting multiple list/audience combinations
++ multiple forms on the same page, for the same list
++ a spam protection module
 + a default configuration record assigned in Settings/SiteConfig
 + configurable defaults in yaml
 + queued jobs to handle subscription and failure checking
-+ a Mailchimp model admin to view subscriptions and subscription results
-+ an elemental subscription form element
-+ Merge Fields support
-+ Tags for subscribers
-+ ability to submit a form with or without (via XHR) redirecting.
++ a Mailchimp model admin to view current subscriptions and subscription results
++ an [Elemental](https://github.com/silverstripe/silverstripe-elemental) subscription form element - [documentation](./docs/en/003_elemental.md)
++ merge fields support
++ tags for subscribers
++ ability to submit a form with or without (via XHR) redirecting
++ patch previously subscribed list/audience members
++ optionally remove current subscriber tags
 
-### Setup
+It doesn't support:
 
-+ Configure your Mailchimp API key and list (audience)
-+ Set up one or more configurations, assign one as the default
-+ Ensure queues are running
++ Managing audience members, use the Mailchimp administration area for that.
+
+## Setup
+
++ Configure your Mailchimp API key and list (audience). You will find this in the Mailchimp account settings and relevant audience, respectively.
++ In your website, set up one or more configurations
++ Assign one of those as the default for the website
++ Ensure queues are running, or get a developer to do this for you.
 + Test a subscription to your lists
 
 [Further documentation beyond the basics is available](./docs/en/001_index.md)
 
-### Templating
-
-To include a subscribe form using the default configuration:
-
-Use the include provided by the module
-```
-<% include ChimpleGlobalSubscribeForm %>
-```
-OR, call the global template variable in a template
-```
-$ChimpleGlobalSubscribeForm
-```
-
-To include a subscriber form using the a specific configuration record, specify the `MailchimpConfiguration.Code` value:
-
-Use the include provided by the module
-```
-<% include ChimpleSubscribeForm Code='footer-form' %>
-```
-OR
-```
-$ChimpleSubscribeForm('footer-form')
-```
-
-### Specifying XHR submission in the template
-
-The administration area allows users with permissions to set whether a form should submit via XHR. This can be modified in the template using a 2nd argument:
-
-
-#### Allow the configuration record to decide:
-```
-$ChimpleGlobalSubscribeForm('footer-form')
-```
-
-#### Force XHR off
-```
-$ChimpleGlobalSubscribeForm('footer-form', 0)
-```
-
-#### Force XHR on
-```
-$ChimpleGlobalSubscribeForm('footer-form')
-```
-
-
-### Submission endpoint
-
-Forms will post to the module's controller endpoint
-
-### DOM id clashes
-
-If, for some reason you want to add the same subscription for multiple times in a page, add multiple configurations for the same List (audience) ID and have one form/element per configuration.
-
-### CSS and JS
-
-The module provides basic HTML and no CSS by default, further integration into your project is up to you or your developer.
-
-### Content element
-
-A subscription element for use with the Elemental module is provided. Content authors can add a subscription form to a page and configure:
-
-+ submitting with/without redirect
-+ the audience ID value
-+ before/after HTML content to render with the form
-
-## Requirements
-
-See [composer.json](./composer.json)
-
-## Installation
-
-```
-composer require nswdpc/silverstripe-chimple
-```
-
-## License
-
-BSD-3-Clause
-
-See [License](./LICENSE.md)
-
 ## Configuration
 
-Example project configuration for your project
+Example project configuration:
 
 ```yaml
 ---
@@ -124,6 +54,44 @@ NSWDPC\Chimple\Models\MailchimpConfig:
   list_id: '<list id>'
 ```
 
+[Further integration](./docs/en/002_integration.md)
+
+## Spam protection
+
+Use a [spam protection module](https://github.com/silverstripe/silverstripe-spamprotection) to block spammy submission attempts on the form. The [NSWDPC reCAPTCHAv3 module](https://github.com/nswdpc/silverstripe-recaptcha-v3) is a good option.
+
+If a module is installed, the subscription form will detect this and enable the default spam protector on the form.
+
+## Cache-control support
+
+All forms in Silverstripe [set cache control headers to a non-cacheable state](https://docs.silverstripe.org/en/4/developer_guides/performance/http_cache_headers/#http-cache-headers), unless they use GET as a form submission method and the CSRF token is turned off.
+
+To set cache control headers for a cacheable state:
+
+1. enable `use_get` and  `disable_security_token` on the [controller](/blob/master/src/Controllers/ChimpleController.php)
+1. use the XHR option as this will POST form data to the backend
+1. use a form spam protection module to avoid/minimise robotic submissions (see above)
+
+Note that other forms included in the page may disable a cacheable state.
+
+## Requirements
+
+See [composer.json](./composer.json)
+
+## Installation
+
+The only supported method of installation is via composer:
+
+```shell
+composer require nswdpc/silverstripe-chimple
+```
+
+## License
+
+BSD-3-Clause
+
+See [License](./LICENSE.md)
+
 ## Maintainers
 
 NSW DPC Digital
@@ -135,6 +103,10 @@ This module is a combination of work contributed to various projects over the ye
 ## Bugtracker
 
 Please raise bugs (with instructions on how to reproduce), questions and feature requests on the Github bug tracker
+
+## Security
+
+If you have found a security issue with this module, please email digital[@]dpc.nsw.gov.au in the first instance, detailing your findings.
 
 ## Development and contribution
 

--- a/docs/en/001_index.md
+++ b/docs/en/001_index.md
@@ -1,40 +1,92 @@
 # Documentation
 
-Further documentation will be added here (or open a PR to contribute it)
-
 ## Contents
 
++ Configuration defaults in the administration area
++ The subscription process
 + Submitting without a redirect
 + Using multiple forms for the same Mailchimp audience ID
++ [Developer integration](./002_integration.md)
++ [Elemental support](./003_elemental.md)
+
+## Configuration defaults
+
+If you have access to the `Mailchimp Configuration` administration area you may add, remove and update configurations.
+Each configuration can be used to allow site visitors to subscribe to a Mailchimp list with various default options based on the values you provide.
+
++ Title: this value is used in the administration area only
++ Submit without redirecting (see below)
++ Code: a unique code used to represent this record. It can be used by a developer to include a subscription form in a page statically (eg. a universal footer or header form)
++ Heading: this will be displayed at the top of the form, if provided
++ Mailchimp list id: the value retrieved from the "Audience name and defaults" page in the Mailchimp administration area. It could be noted as the "Audience ID" or "List ID" and looks something like `abc45de6`
++ Content to show before form: HTML content of your choosing. This can be overridden in the Elemental element
++ Content to show after form: HTML content of your choosing. This can be overridden in the Elemental element
++ Tags assigned to the subscriber: assign default tags when a subscriber successfully subscribes via this form. This can assist with analytics to determine which forms perform the best or worst.
+
+## The subscription process
+
+When a user successfully submits the subscription form, they will enter a queue awaiting submission to Mailchimp. The frequency of the submission is determined by the queue configuration. By default it runs every 300 seconds (5 minutes).
+
+Each subscription record will have one of the following values:
++ New: the subscription attempt has not yet been made
++ Processing: the record is in the process of being subscribed
++ Success: Mailchimp accepted the subscription creation/update request
++ Fail: Mailchimp denied the subscription creation/update request (see Last error value for possible reasons)
+
+All subscribers are created as "pending" by default. They will receive a double opt-in email for Mailchimp to confirm that they actually were the website visitor entering their own email address.
+
+Once the visitor confirms their subscription, they will appear in the Mailchimp audience list on your Mailchimp website control panel. In your website their name and email address will be obfuscated by default eg. `T•••y`
+
+If a visitor resubscribes to the same list, the values they provide will update their Mailchimp audience values for that list. This includes adding new default tags.
+
+If a subscription fails, this will be noted in the Mailchimp subscriber administration area of your website.
+
+## Cleanup
+
+Subscription attempts are removed from your website with the following schedule:
+
++ 30 minutes for successful subscriptions
++ 7 days for failed subscriptions. This allows you to retry subscriptions as required.
+
+To retry a failed subscription, set their "Status" to "New" and it will be picked up on the next queue run. Note that it may fail again.
 
 ## Submitting without a redirect
 
-### Developers
+## For content authors and administrators
 
-By default, the global form will submit without a redirect.
+If you have access to the Mailchimp Configuration admninistration area, checking the `Submit without redirecting` checkbox will cause the form for that configuration to submit without a redirect.
 
-The global form is one added to your template via the `$ChimpleGlobalSubscribeForm` template variable. It will use the `use_xhr` setting specified in config.yml:
-
-+ true: submit using XHR
-+ false: submit with a redirect
-+ null: let the checkbox value for the Default configuration record in the administration area decide
-
-## Content authors and administrators
-
-If you have access to the Mailchimp Configuration admninistration are, checking the `Submit without redirecting` checkbox will cause the form for that configuration to submit without redirect.
+This means that the person subscribing will see the subscription result on the same page as the form they have just submitted.
 
 <img src="../img/config_usexhr.png">
 
 <hr>
 
-If you are a content author, you can select a Mailchimp Configuration and optionally override it's setting using the content element's `Submit without redirecting` option
+If you are a content author, you can select a Mailchimp Configuration and optionally override its setting using the content element's `Submit without redirecting` option
 
 <img src="../img/element_usexhr.png">
 
+### For developers
+
+By default, the global form will submit in place via an AJAX (XHR) submission.
+
+The global form is one added to your template via the `$ChimpleGlobalSubscribeForm` template variable. It will use the `use_xhr` value specified in config.yml
+
+```yaml
+NSWDPC\Chimple\Models\MailchimpConfig:
+  use_xhr: true|false|null
+```
+
++ `true`: submit using XHR
++ `false`: submit with a redirect
++ `null`: let the checkbox value for the Default configuration record in the administration area decide
+
+Note that using XHR submissions will assist in maintaining cacheable cache-control headers.
+
 ## Adding multiple forms for the same audience
 
-You can add multiple forms for the same Mailchimp audience ID by creating one configuration for each copy you need. Set the `Code` value for each copy to be unique and represent what the form does or the context that it has.
+You can add multiple forms for the same Mailchimp audience by creating one configuration for each copy you need. Set the `Code` value for each copy to be unique and represent what the form does or the context that it has.
 
-Each configuration will be given a random code on save, if non is provided.
+Each configuration will be given a random code on save, if none is provided.
 
-The `Code` value is used in HTML, so putting identifiable text in it is not advised.
+The `Code` value is used in HTML so putting identifiable text in it is not advised.

--- a/docs/en/002_integration.md
+++ b/docs/en/002_integration.md
@@ -1,0 +1,77 @@
+# Integration
+
+This page contains further developer integration documentation.
+
+## Templating
+
+### The global form
+
+To include a subscribe form using the default configuration:
+
+Use the include provided by the module
+```ss
+<% include ChimpleGlobalSubscribeForm %>
+```
+OR, call the global template variable in a template
+```ss
+$ChimpleGlobalSubscribeForm
+```
+
+### For a specific form configuration
+
+To include a subscriber form using the a specific configuration record, specify the `MailchimpConfiguration.Code` value:
+
+Use the include provided by the module
+```ss
+<% include ChimpleSubscribeForm Code='footer-form' %>
+```
+OR
+```ss
+$ChimpleSubscribeForm('footer-form')
+```
+
+(This requires a Mailchimp Configuration record with a code of 'footer-form' to be present)
+
+### Specifying XHR submission in the template
+
+The administration area allows users with permissions to set whether a form should submit via XHR (submit without redirecting). This is useful when forms are used in a publicly cached page.
+
+The behaviour for a form can be set in code via a template using a 2nd argument to `$ChimpleSubscribeForm`
+
+> Turning this on/off via a template will override whatever configuration setting is set in the administration area for the relevant subscription form.
+
+####  Allow the configuration record to decide:
+```ss
+$ChimpleSubscribeForm('footer-form')
+```
+
+#### Force XHR off
+```ss
+$ChimpleSubscribeForm('footer-form', 0)
+```
+
+#### Force XHR on
+```ss
+$ChimpleSubscribeForm('footer-form', 1)
+```
+
+## Good-to-know
+
+### Submission endpoint
+
+Form data will post to the module's ChimpleController endpoint
+
+### DOM id clashes
+
+If you want to add the same subscription form multiple times in a page, add multiple configurations for the same List (audience) ID and have one form/element per configuration.
+
+### HTML templating
+
+The module provides basic HTML and no CSS by default:
+
++ Content before the form, if it exists
++ An image if it exists
++ The form
++ Content after the form, if it exists
+
+Further integration into your project is up to you or your developer.

--- a/docs/en/003_elemental.md
+++ b/docs/en/003_elemental.md
@@ -1,0 +1,10 @@
+# Elemental
+
+A subscription element for use with the [Elemental module](https://github.com/silverstripe/silverstripe-elemental) is provided.
+
+This allows content authors to add one or more subscription forms to a page's elemental area and configure:
+
++ submitting with/without redirect
++ the audience (list) used
++ before/after HTML content to render with the form
++ an image to include in the form

--- a/src/Controllers/ChimpleController.php
+++ b/src/Controllers/ChimpleController.php
@@ -324,10 +324,6 @@ class ChimpleController extends PageController
                 $sub->Email = $data['Email'];
                 $sub->MailchimpListId = $list_id;//list they are subscribing to
                 $sub->Status = MailchimpSubscriber::CHIMPLE_STATUS_NEW;
-                $sub->UpdateExisting = $mc_config->UpdateExisting;
-                $sub->SendWelcome = $mc_config->SendWelcome;
-                $sub->ReplaceInterests = $mc_config->ReplaceInterests;
-                $sub->DoubleOptIn = $mc_config->DoubleOptIn;
                 $sub->Tags = $mc_config->Tags;
                 $sub_id = $sub->write();
                 if (!$sub_id) {

--- a/src/Jobs/MailchimpSubscribeJob.php
+++ b/src/Jobs/MailchimpSubscribeJob.php
@@ -14,7 +14,7 @@ class MailchimpSubscribeJob extends AbstractQueuedJob implements QueuedJob
 {
     use Configurable;
 
-    private static $run_in_seconds = 300;
+    private static $run_in_seconds = 60;
     private static $default_limit = 100;
 
     public function __construct($limit = 100, $report_only = 0)
@@ -90,9 +90,9 @@ class MailchimpSubscribeJob extends AbstractQueuedJob implements QueuedJob
     {
         $run_datetime = new DateTime();
         $seconds  = (int)$this->config()->get('run_in_seconds');
-        if ($seconds <= 120) {
-            // min every 2 minutes
-            $seconds = 120;
+        if ($seconds <= 30) {
+            // min every 30s
+            $seconds = 30;
         }
         $run_datetime->modify("+{$seconds} seconds");
         singleton(QueuedJobService::class)->queueJob(

--- a/src/Models/MailChimpConfig.php
+++ b/src/Models/MailChimpConfig.php
@@ -14,6 +14,7 @@ use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use Silverstripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
+use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Security\PermissionProvider;
 use SilverStripe\Security\Permission;
 use SilverStripe\SiteConfig\SiteConfig;
@@ -31,7 +32,6 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
 
     private static $list_id = "";// default list (audience) ID
     private static $api_key = "";// API key provided by Mailchimp
-    private static $double_optin = true;// have a good reason to set to false
     private static $use_xhr = true;//whether to use XHR for submissions
 
     private static $success_message = "Thank you for subscribing. You will receive an email to confirm your subscription shortly.";
@@ -56,10 +56,10 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
         'Heading' => 'Varchar(255)',
         'MailchimpListId' => 'Varchar(255)',//list to subscribe people to
         'ArchiveLink' =>  'Varchar(255)',//link to newsletter archive page for the list
-        'UpdateExisting' => 'Boolean',
-        'SendWelcome' => 'Boolean',
-        'ReplaceInterests' => 'Boolean',
-        'DoubleOptIn' => 'Boolean',// whether to double opt-in subscribers for this configuration
+        'UpdateExisting' => 'Boolean',// @deprecated
+        'SendWelcome' => 'Boolean',// @deprecated
+        'ReplaceInterests' => 'Boolean',// @deprecated
+        'DoubleOptIn' => 'Boolean',// @deprecated
         // for storing tags to submit with subscriber
         'Tags' => 'MultiValueField',
         'UseXHR' => 'Boolean',// whether to submit without redirect
@@ -78,7 +78,6 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
         'IsGlobal.Nice' => 'Default',
         'Heading' => 'Heading',
         'MailchimpListId' => 'List',
-        'DoubleOptIn' => 'Double Opt-in',
         'UseXHR.Nice' => 'Submit w/o redirect'
     ];
 
@@ -92,10 +91,10 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
      * @var array
      */
     private static $defaults = [
-        'UpdateExisting' => 1,
-        'SendWelcome' => 0,
-        'ReplaceInterests' => 0,
-        'DoubleOptIn' => 1,
+        'UpdateExisting' => 1,// @deprecated
+        'SendWelcome' => 0,// @deprecated
+        'ReplaceInterests' => 0,// @deprecated
+        'DoubleOptIn' => 1,// @deprecated
         'IsGlobal' => 0,
         'UseXHR' => 1
     ];
@@ -208,6 +207,14 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();
+
+        // remove deprecated fields
+        $fields->removeByName([
+            'UpdateExisting',
+            'SendWelcome',
+            'ReplaceInterests',
+            'DoubleOptIn'
+        ]);
 
         $api_key = self::getApiKey();
         if (!$api_key) {
@@ -475,7 +482,7 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
      * The 2nd parameter is a 1 or 0 representing whether to handle the submission via XHR
      * This is called from a template calling $ChimpleSubscribeForm('code'[,0|1])
      * @param array
-     * @return string|null
+     * @return DBHTMLText|null
      */
     public static function get_chimple_subscribe_form(...$args)
     {
@@ -503,7 +510,7 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
     /**
      * Get the subscribe form for the current global config
      * This is called from a template calling $ChimpleSubscribeForm('code')
-     * @return string|null
+     * @return DBHTMLText|null
      */
     public static function get_chimple_global_subscribe_form()
     {

--- a/src/Models/MailChimpConfig.php
+++ b/src/Models/MailChimpConfig.php
@@ -119,6 +119,20 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
         return Config::inst()->get(MailchimpConfig::class, 'api_key');
     }
 
+    /**
+     * Returns the data centre (dc) component based on the API key e.g us2
+     * @return string
+     */
+    public static function getDataCentre() : string {
+        $dc = '';
+        $key = self::getApiKey();
+        $parts = [];
+        if($key) {
+            $parts = explode("-", $key);
+        }
+        return !empty($parts[1]) ? $parts[1] : '';
+    }
+
     public function TitleWithCode() {
         return $this->Title . " - (code {$this->Code})";
     }

--- a/src/Models/MailchimpSubscriber.php
+++ b/src/Models/MailchimpSubscriber.php
@@ -210,10 +210,18 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
             ]
         );
 
+        // get profile link
+        $dc = MailChimpConfig::getDataCentre();
+        if($dc && $this->SubscribedWebId) {
+            $subscriber_profile_link = "https://{$dc}.admin.mailchimp.com/lists/members/view?id={$this->SubscribedWebId}";
+        } else {
+            $subscriber_profile_link = "n/a";
+        }
+
         $readonly_fields = [
             'MailchimpListId' => _t(__CLASS__ . '.SUBSCRIBER_LIST_ID', "The Mailchimp List (audience) Id for this subscription record"),
             'SubscribedUniqueEmailId' => _t(__CLASS__ . '.SUBSCRIBER_UNIQUE_EMAIL_ID', "An identifier for the address across all of Mailchimp."),
-            'SubscribedWebId' => _t(__CLASS__ . '.SUBSCRIBER_WEB_ID', "The ID used in the Mailchimp web application. View this member in your Mailchimp account at https://{dc}.admin.mailchimp.com/lists/members/view?id={web_id}"),
+            'SubscribedWebId' => _t(__CLASS__ . '.SUBSCRIBER_WEB_ID', "Member profile page: {link}", ['link' => $subscriber_profile_link]),
             'SubscribedId' => _t(__CLASS__ . '.SUBSCRIBER_ID', "The MD5 hash of the lowercase version of the list member's email address.")
         ];
 

--- a/src/Models/MailchimpSubscriber.php
+++ b/src/Models/MailchimpSubscriber.php
@@ -6,6 +6,9 @@ use DrewM\MailChimp\MailChimp as MailchimpApiClient;
 use NSWDPC\Chimple\Services\Logger;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\ReadonlyField;
+use SilverStripe\Forms\LiteralField;
+use SilverStripe\Control\Email\Email;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Security\PermissionProvider;
 use SilverStripe\Security\Permission;
@@ -15,6 +18,7 @@ use Symbiote\MultiValueField\Fields\MultiValueTextField;
 
 class MailchimpSubscriber extends DataObject implements PermissionProvider
 {
+    const CHIMPLE_STATUS_UNKNOWN = '';
     const CHIMPLE_STATUS_NEW = 'NEW';
     const CHIMPLE_STATUS_PROCESSING = 'PROCESSING';
     const CHIMPLE_STATUS_BATCHED = 'BATCHED';
@@ -26,6 +30,15 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
     const MAILCHIMP_SUBSCRIBER_UNSUBSCRIBED = 'unsubscribed';
     const MAILCHIMP_SUBSCRIBER_CLEANED = 'cleaned';
 
+    const MAILCHIMP_TAG_INACTIVE = 'inactive';
+    const MAILCHIMP_TAG_ACTIVE = 'active';
+
+    const MAILCHIMP_EMAIL_TYPE_HTML = 'html';
+    const MAILCHIMP_EMAIL_TYPE_TEXT = 'text';
+
+    /**
+     * @var string
+     */
     private static $table_name = 'ChimpleSubscriber';
 
     /**
@@ -52,6 +65,24 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
      */
     private static $obfuscation_chr = "•";
 
+    /**
+     * Email type, defaults to 'html', other value is 'text'
+     * @var string
+     */
+    private static $email_type = self::MAILCHIMP_EMAIL_TYPE_HTML;
+
+    /**
+     * Remove tags that do not exist in the tags list when a subscriber
+     * attempts to update their subscription
+     * This is a potentially destructive action as it will remove tags added to
+     * a subscriber via other means
+     * @var string
+     */
+    private static $remove_subscriber_tags = false;
+
+    /**
+     * @var array
+     */
     private static $db = [
         'Name' => 'Varchar(255)',
         'Surname' => 'Varchar(255)',
@@ -60,11 +91,10 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
         'MailchimpListId' => 'Varchar(255)',//list id the subscriber was subscribed to
         'LastError' => 'Text',
         'Status' => 'Varchar(12)',// arbitrary status (see const CHIMPLE_STATUS_*)
-        // these values are set when subscribe record is created
-        'UpdateExisting' => 'Boolean',
-        'SendWelcome' => 'Boolean',
-        'ReplaceInterests' => 'Boolean',
-        'DoubleOptIn' => 'Boolean',
+        'UpdateExisting' => 'Boolean',// @deprecated
+        'SendWelcome' => 'Boolean',// @deprecated
+        'ReplaceInterests' => 'Boolean',// @deprecated
+        'DoubleOptIn' => 'Boolean',// @deprecated
 
         // for responses
         'SubscribedUniqueEmailId' => 'Varchar(255)',
@@ -97,10 +127,10 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
      */
     private static $defaults = [
         'Status' => self::CHIMPLE_STATUS_NEW,
-        'UpdateExisting' => 1,
-        'SendWelcome' => 0,
-        'ReplaceInterests' => 0,
-        'DoubleOptIn' => 1 // by default everyone has double-opt-in
+        'UpdateExisting' => 1,// @deprecated
+        'SendWelcome' => 0,// @deprecated
+        'ReplaceInterests' => 0,// @deprecated
+        'DoubleOptIn' => 1// @deprecated
     ];
 
     /**
@@ -132,7 +162,18 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
         'Status' => 'PartialMatchFilter',
     ];
 
-    private $mailchimp = null;// mailchimp API client
+    /**
+     * @var DrewM\MailChimp\MailChimp
+     * The Mailchimp API client instance
+     */
+    protected static $mailchimp = null;
+
+    /**
+     * List of current subscriber tags
+     * @var array|null
+     */
+    private $_cache_tags = null;
+
 
     /**
      * Return whether subscription was success
@@ -141,7 +182,6 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
     {
         return $this->Status == self::CHIMPLE_STATUS_SUCCESS;
     }
-
     /**
      * CMS Fields
      * @return FieldList
@@ -149,6 +189,14 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();
+
+        // remove deprecated fields
+        $fields->removeByName([
+            'UpdateExisting',
+            'SendWelcome',
+            'ReplaceInterests',
+            'DoubleOptIn'
+        ]);
 
         $fields->removeByName([
             'FailNoticeSent'
@@ -159,31 +207,96 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
             ->setDescription(
                 _t(
                     __CLASS__. '.IF_ERROR_OCCURRED',
-                    "If an error occurred, this will display the last error returned by Mailchimp"
+                    "If a subscription error occurred, this will display the last error returned by Mailchimp and can help determine the cause of the error"
                 )
             )
         );
 
-        $fields->addFieldToTab(
-            'Root.Main',
-            DropdownField::create(
+        // status field
+        if($this->exists()) {
+            $status_field = DropdownField::create(
                 'Status',
                 _t(__CLASS__ . '.STATUS', 'Status'),
                 [
+                    self::CHIMPLE_STATUS_UNKNOWN => '',
                     self::CHIMPLE_STATUS_NEW => _t(__CLASS__ . '.STATUS_NEW', 'NEW (the subscriber has not yet been subscribed)'),
                     self::CHIMPLE_STATUS_PROCESSING => _t(__CLASS__ . '.STATUS_PROCESSING', 'PROCESSING (the subscriber is in the process of being subscribed)'),
                     self::CHIMPLE_STATUS_SUCCESS => _t(__CLASS__ . '.STATUS_SUCCESS', 'SUCCESS (the subscriber was subscribed)'),
                     self::CHIMPLE_STATUS_FAIL => _t(__CLASS__ . '.STATUS_FAIL', 'FAIL (the subscriber could not be subscribed - check the \'Last Error\' value)')
                 ]
-            )->setEmptyString('')
-            ->setDescription(
-                _t(
-                    __CLASS__ . '.USE_CARE_STATUS',
-                    "Use care when resetting this value. E.g you can reset the status to NEW to attempt a re-subscription"
-                )
-            ),
-            'LastError'
-        );
+            );
+
+            // only failed, empty or stuck processing subscription status can have their status changed
+            if($this->Status != self::CHIMPLE_STATUS_FAIL
+                && $this->Status != self::CHIMPLE_STATUS_PROCESSING
+                && !empty($this->Status)) {
+                // these status are readonly in CMS fields
+                $status_field = $status_field->performReadonlyTransformation();
+            } else if($this->Status == self::CHIMPLE_STATUS_PROCESSING) {
+                // stuck processing - can reset to new
+                $status_field->setDescription(
+                    _t(
+                        __CLASS__ . '.PROCESSING_RESET_NEW_STATUS',
+                        "If this attempt is stuck, reset to 'New' for another attempt"
+                    )
+                );
+                // can retain failed or set to new for retry
+                $status_field->setSource([
+                    self::CHIMPLE_STATUS_NEW => _t(__CLASS__ . '.STATUS_NEW', 'NEW (the subscriber has not yet been subscribed)'),
+                    self::CHIMPLE_STATUS_PROCESSING =>  _t(__CLASS__ . '.STATUS_PROCESSING', 'PROCESSING (the subscriber is in the process of being subscribed)'),
+                ]);
+            } else if($this->Status == self::CHIMPLE_STATUS_FAIL) {
+                // handling when failed
+                $status_field->setDescription(
+                    _t(
+                        __CLASS__ . '.FAIL_RESET_NEW_STATUS',
+                        "Reset this value to 'New' to retry a failed subscription attempt"
+                    )
+                );
+                // can retain failed or set to new for retry
+                $status_field->setSource([
+                    self::CHIMPLE_STATUS_NEW => _t(__CLASS__ . '.STATUS_NEW', 'NEW (the subscriber has not yet been subscribed)'),
+                    self::CHIMPLE_STATUS_FAIL => _t(__CLASS__ . '.STATUS_FAIL', 'FAIL (the subscriber could not be subscribed - check the \'Last Error\' value)')
+                ]);
+            }
+
+            $fields->addFieldToTab(
+                'Root.Main',
+                $status_field,
+                'LastError'
+            );
+
+        } else {
+            // does not exist yet
+            $fields->removeByName([
+                'Status'
+            ]);
+            $fields->addFieldToTab(
+                'Root.Main',
+                LiteralField::create(
+                    'StatusForNew',
+                    '<p class="message notice">'
+                    . _t(
+                        __CLASS__ . '.STATUS_NEW_MESSAGE',
+                        'This subscription attempt record will be given status of \'New\' and it will enter the pending subscription queue upon save'
+                    )
+                    . '</p>'
+                ),
+                'Name'
+            );
+        }
+
+        $tags = $this->getCurrentSubscriberTags();
+        $tag_field_description = "";
+        if(!empty($tags)) {
+            $tag_field_description = _t(
+                __CLASS__ . '.TAGS_FIELD_DESCRIPTION',
+                'The current tags for this subscriber are <code>{tags}</code><br>Tags not in the tag update list will be removed. New tags will be added.',
+                [
+                    'tags' => implode(", ", $tags)
+                ]
+            );
+        }
 
         $fields->addFieldsToTab(
             'Root.Main',
@@ -192,7 +305,7 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
                     'MergeFields',
                     _t(
                         __CLASS__ . '.MERGE_FIELDS',
-                        'Merge fields for subscription'
+                        'Merge fields for this subscription attempt'
                     )
                 )->setDescription(
                     _t(
@@ -204,8 +317,10 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
                     'Tags',
                     _t(
                         __CLASS__ . '.TAGS_FIELD',
-                        'Tags for this subscriber'
+                        'Tag update list'
                     )
+                )->setDescription(
+                    $tag_field_description
                 )
             ]
         );
@@ -245,6 +360,12 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
     public function onBeforeWrite()
     {
         parent::onBeforeWrite();
+
+        if(!$this->exists()) {
+            // new subscribers have a new status by default
+            $this->Status = self::CHIMPLE_STATUS_NEW;
+        }
+
         if (empty($this->Surname)) {
             $this->Surname = $this->getSurnameFromName();
             // reset name
@@ -299,14 +420,24 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
      * Get the API client
      * @return DrewM\Mailchimp\Mailchimp
      */
-    public function getMailchimp()
-    {
+    public static function api() : MailchimpApiClient {
+        // already set up..
+        if(self::$mailchimp instanceof MailchimpApiClient) {
+            return self::$mailchimp;
+        }
         $api_key = MailchimpConfig::getApiKey();
         if (!$api_key) {
             throw new Exception("No Mailchimp API Key configured!");
         }
-        $this->mailchimp = new MailchimpApiClient($api_key);
-        return $this->mailchimp;
+        self::$mailchimp = new MailchimpApiClient($api_key);
+        return self::$mailchimp;
+    }
+
+    /**
+     * @deprecated use self::api() instead
+     */
+    public function getMailchimp() {
+        return self::api();
     }
 
     /**
@@ -363,42 +494,22 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
     }
 
     /**
-     * Get the subscription record data for adding/updating member in list
-     * @param string $existing_status for updates to subscription status, the subscribers's current status
+     * Get the default subscription record data for adding/updating member in list
      * @return array
      */
-    public function getSubscribeRecord($existing_status = '') {
-
+    public function getSubscribeRecord() : array {
         // merge fields to send
         $merge_fields = $this->applyMergeFields();
-
-        // status: subscribed unsubscribed cleaned pending
-        $double_optin = $this->DoubleOptIn == 1;
-
+        // ensure sane email type either html or text, default html if invalid
+        $email_type = $this->config()->get('email_type');
+        if(!$email_type || $email_type != self::MAILCHIMP_EMAIL_TYPE_HTML || $email_type != self::MAILCHIMP_EMAIL_TYPE_TEXT) {
+            $email_type = self::MAILCHIMP_EMAIL_TYPE_HTML;
+        }
         $params = [
             'email_address' => $this->Email,
-            'double_optin' => $double_optin,// @deprecated
-            'merge_fields' => $merge_fields,
-            'update_existing' => $this->UpdateExisting,// @deprecated
-            'replace_interests' => $this->ReplaceInterests,// @deprecated
-            'send_welcome' => $this->SendWelcome,// @deprecated
-            'tags' => $this->getSubscriberTags()
+            'email_type' => $email_type,
+            'merge_fields' => $merge_fields
         ];
-
-        if(!$existing_status) {
-            if (!$double_optin) {
-                // subscribed when doubleoptin is off
-                $status = self::MAILCHIMP_SUBSCRIBER_SUBSCRIBED;
-            } else {
-                // pending when doubleoptin is on
-                $status = self::MAILCHIMP_SUBSCRIBER_PENDING;
-            }
-            $params['status'] = $status;
-        } else {
-            // use existing_status as it is a required field
-            $params['status'] = $existing_status;
-        }
-
         return $params;
     }
 
@@ -450,15 +561,13 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
     }
 
     /**
-     * Check if a  given email address exists in the given list (audience)
+     * Check if a given email address exists in the given list (audience)
      * @param string $list_id the Audience ID
      * @param string $email an email address, this is hashed using the MC hashing strategy
-     * @param string $api_key you can optionally provide another API key, other than the one configured.
-     *               If this is not provided, the configured one is used
-     * @return boolean
+     * @param string $api_key @deprecated
+     * @return boolean|array
      */
     public static function checkExistsInList(string $list_id, string $email, string $api_key = '') {
-
 
         // sanity check on input
         if(!$email) {
@@ -479,25 +588,9 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
             );
         }
 
-        // can provide an API key as a param
-        if(!$api_key) {
-            $api_key = MailchimpConfig::getApiKey();
-            if (!$api_key) {
-                throw new Exception(
-                    _t(
-                        __CLASS__ . ".APIKEY_NOT_PROVIDED_CONFIGURED",
-                        "No Mailchimp API Key provided or configured!"
-                    )
-                );
-            }
-        }
-
-        // API client
-        $api = new MailchimpApiClient($api_key);
-
         // attempt to get the subscriber
         $hash = self::getMailchimpSubscribedId($email);
-        $result = $api->get(
+        $result = self::api()->get(
             "lists/{$list_id}/members/{$hash}"
         );
 
@@ -512,14 +605,20 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
 
     /**
      * Subscribe *this* particular record
+     * @return bool
      */
     public function subscribe()
     {
         try {
+
             $last_error = "";
             $list_id = $this->getMailchimpListId();
             if (!$list_id) {
                 throw new Exception("No Mailchimp List/Audience Id configured!");
+            }
+
+            if(!Email::is_valid_address($this->Email)) {
+                throw new Exception("The email address provided for this record is not valid. See RFC822 spec.");
             }
 
             /**
@@ -528,23 +627,34 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
             $existing = self::checkExistsInList($list_id, $this->Email);
 
             $result = false;
-            $api = $this->getMailchimp();
+
             if(!$existing) {
-                // New: subscribe - use POST
-                $result = $api->post(
-                    "lists/{$list_id}/members",
-                    $this->getSubscribeRecord()
-                );
+                $operation_path = "lists/{$list_id}/members";
+                $params = $this->getSubscribeRecord();
+                // add tags
+                $params['tags'] = $this->getSubscriberTags();
+                // new members are pending
+                $params['status'] = self::MAILCHIMP_SUBSCRIBER_PENDING;
+
+                // Attempt subscription of new list member
+                $result = self::api()->post($operation_path, $params);
+                $succeeded = !empty($result['unique_email_id']);
+
             } else {
-                // Current: patch into list
-                $result = $api->patch(
-                    "lists/{$list_id}/members/{$existing['id']}",
-                    // use current status of subscriber, to avoid changing it
-                    $this->getSubscribeRecord($existing['status'])
-                );
+                $operation_path = "lists/{$list_id}/members/{$existing['id']}";
+                $params = $this->getSubscribeRecord();
+                // Use current status
+                $params['status'] = $existing['status'];
+                // Attempt update of subscription of current list member
+                $result = self::api()->patch($operation_path, $params);
+                $succeeded = !empty($result['unique_email_id']);
+                // modify tags on success
+                if ($succeeded) {
+                    $this->modifySubscriberTags();
+                }
             }
 
-            if (!empty($result['unique_email_id'])) {
+            if ($succeeded) {
                 // this unique_email_id value is returned when subscribed
                 $this->SubscribedUniqueEmailId = $result['unique_email_id'];
                 $this->SubscribedWebId = $result['web_id'] ?? '';
@@ -580,7 +690,124 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
     }
 
     /**
+     * Return all current tags for a subscriber and handle pagination at the time of the API call
+     * @param bool $force whether to get the tags from the remote or use previously retrieved tags
+     * @param int $count the number of records to return per request
+     * @return array an array of values, each value is a string tag
+     */
+    private function getCurrentSubscriberTags(bool $force = false, int $count = 10) : array {
+
+        // if already retrieved,
+        if(is_array($this->_cache_tags) && !$force) {
+            return $this->_cache_tags;
+        }
+
+        $list_id = $this->MailchimpListId;
+        $subscriber_hash = self::getMailchimpSubscribedId($this->Email);
+
+        if(!$list_id || !$subscriber_hash) {
+            $this->_cache_tags = null;
+            return [];
+        }
+
+        $list = [];
+        $offset = 0;
+        $operation_path = "lists/{$list_id}/members/{$subscriber_hash}/tags/?count={$count}&offset={$offset}";
+
+        $result = self::api()->get($operation_path);
+        $total = isset($result['total_items']) ? $result['total_items'] : 0;
+        // initial set of tags
+        $tags = isset($result['tags']) && is_array($result['tags']) ? $result['tags'] : [];
+
+        // populate the list of tags
+        $walker = function($value, $key) use (&$list) {
+            $list[] = $value['name'];
+        };
+        array_walk($tags, $walker);
+
+        if($total > $count) {
+            // e.g if 11 returned, there are 2 pages with 10 per page
+            $pages = ceil($total / $count);
+            $p = 1;
+            while($p < $pages) {
+                // update offset
+                $offset = $p * $count;
+                $operation_path = "lists/{$list_id}/members/{$subscriber_hash}/tags/?count={$count}&offset={$offset}";
+                $result = self::api()->get($operation_path);
+                $tags = isset($result['tags']) && is_array($result['tags']) ? $result['tags'] : [];
+                array_walk($tags, $walker);
+                $p++;
+            }
+        }
+
+        $this->_cache_tags = $list;
+        return $list;
+    }
+
+    /**
+     * Modify this subscriber's tags based on their current tags
+     */
+    protected function modifySubscriberTags() : bool {
+
+        $current = $this->getCurrentSubscriberTags();
+        $tags_for_update = $this->getSubscriberTags();
+
+        $params = [];
+        $params['tags'] = [];
+
+        // if enabled: remove tags that do not exist in the modification list
+        if($this->config()->get('remove_subscriber_tags')) {
+            $inactive = array_diff($current,$tags_for_update);
+            // Mark removed tags as inactive
+            foreach($inactive as $tag) {
+                $params['tags'][] = [
+                    'name' => $tag,
+                    'status' => self::MAILCHIMP_TAG_INACTIVE
+                ];
+            }
+        }
+
+        // Retain active tags that are in both lists
+        $retained = array_intersect($current,$tags_for_update);
+        foreach($retained as $tag) {
+            $params['tags'][] = [
+                'name' => $tag,
+                'status' => self::MAILCHIMP_TAG_ACTIVE
+            ];
+        }
+
+        // DOCS
+        // "If a tag that does not exist is passed in and set as 'active', a new tag will be created."
+        $new = array_diff($tags_for_update, $current);
+        foreach($new as $tag) {
+            $params['tags'][] = [
+                'name' => $tag,
+                'status' => self::MAILCHIMP_TAG_ACTIVE
+            ];
+        }
+
+        // operating on the current record
+        $list_id = $this->MailchimpListId;
+        $subscriber_hash = self::getMailchimpSubscribedId($this->Email);
+        $operation_path = "/lists/{$list_id}/members/{$subscriber_hash}/tags";
+
+        // submit payload to API
+        $result = self::api()->post(
+            $operation_path,
+            $params
+        );
+
+        if($error = self::api()->getLastError()) {
+            Logger::log("FAIL:{$error} List:{$list_id}", 'WARNING');
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    /**
      * Batch subscribe via API - hit from MailchimpSubscribeJob
+     * Retrieve all subscribers marked new and attempt to subscribe them
      * @return array
      */
     public static function batch_subscribe($limit = 100, $report_only = false)
@@ -596,30 +823,29 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
             if ($report_only) {
                 $results[ self::CHIMPLE_STATUS_PROCESSING ] = $subscribers->count();
                 foreach ($subscribers as $subscriber) {
-                    Logger::log("Would subscribe #{$subscriber->ID} to list {$subscriber->MailchimpListId}", 'DEBUG');
+                    Logger::log("REPORT_ONLY: would subscribe #{$subscriber->ID} to list {$subscriber->MailchimpListId}", 'DEBUG');
                 }
                 return $results;
             }
 
             // no report_only
-            if ($subscribers->count() > 0) {
-                foreach ($subscribers as $subscriber) {
-                    // set in processing status
-                    $subscriber->Status = self::CHIMPLE_STATUS_PROCESSING;
-                    $subscriber->write();
-                    $subscribe = $subscriber->subscribe();
+            foreach ($subscribers as $subscriber) {
+                // set in processing status
+                $subscriber->Status = self::CHIMPLE_STATUS_PROCESSING;
+                $subscriber->write();
+                // attempt subscription
+                $subscribe = $subscriber->subscribe();
 
-                    if (!isset($results[ $subscriber->Status ])) {
-                        // set status to 0
-                        $results[ $subscriber->Status ] = 0;
-                    }
-                    // increment this status
-                    $results[ $subscriber->Status ]++;
+                if (!isset($results[ $subscriber->Status ])) {
+                    // set status to 0
+                    $results[ $subscriber->Status ] = 0;
                 }
+                // increment this status
+                $results[ $subscriber->Status ]++;
             }
             return $results;
         } catch (Exception $e) {
-            Logger::log($e->getMessage(), 'NOTICE');
+            Logger::log("FAIL: could not batch_subscribe, error=" . $e->getMessage(), 'NOTICE');
         }
 
         return false;

--- a/templates/NSWDPC/Chimple/Models/Elements/ElementChimpleSubscribe.ss
+++ b/templates/NSWDPC/Chimple/Models/Elements/ElementChimpleSubscribe.ss
@@ -3,7 +3,7 @@
     <div class="element element-content<% if $StyleVariant %> $StyleVariant<% end_if %>">
 
         <% if $BeforeFormContent %>
-            <div class="before">
+            <div class="content pre">
                 {$BeforeFormContent}
             </div>
         <% end_if %>
@@ -19,7 +19,7 @@
         </div>
 
         <% if $BeforeFormContent %>
-            <div class="after">
+            <div class="content post">
                 {$BeforeFormContent}
             </div>
         <% end_if %>

--- a/templates/NSWDPC/Chimple/Models/Elements/ElementChimpleSubscribe.ss
+++ b/templates/NSWDPC/Chimple/Models/Elements/ElementChimpleSubscribe.ss
@@ -1,6 +1,28 @@
 <% if $SubscribeForm %>
-<% include ChimpleSubscribeTitle %>
-<div class="element element-content<% if $StyleVariant %> $StyleVariant<% end_if %>">
-    {$SubscribeForm}
-</div>
+    <% include ChimpleSubscribeTitle %>
+    <div class="element element-content<% if $StyleVariant %> $StyleVariant<% end_if %>">
+
+        <% if $BeforeFormContent %>
+            <div class="before">
+                {$BeforeFormContent}
+            </div>
+        <% end_if %>
+
+        <% if $Image %>
+            <div class="image">
+                {$Image}
+            </div>
+        <% end_if %>
+
+        <div class="form">
+            {$SubscribeForm}
+        </div>
+
+        <% if $BeforeFormContent %>
+            <div class="after">
+                {$BeforeFormContent}
+            </div>
+        <% end_if %>
+
+    </div>
 <% end_if %>

--- a/templates/NSWDPC/Chimple/Models/MailchimpConfig.ss
+++ b/templates/NSWDPC/Chimple/Models/MailchimpConfig.ss
@@ -1,6 +1,29 @@
 <div class="subscribe">
-<% if $Heading %><h3>{$Heading.XML}</h3><% end_if %>
-<% if $BeforeFormContent %><div class="content pre">{$BeforeFormContent.RAW}</div><% end_if %>
-<div class="form">{$Form}</div>
-<% if $AfterFormContent %><div class="content post">{$AfterFormContent.RAW}</div><% end_if %>
+
+<% if $Heading %>
+    <h3>{$Heading.XML}</h3>
+<% end_if %>
+
+<% if $BeforeFormContent %>
+    <div class="content pre">
+        {$BeforeFormContent.RAW}
+    </div>
+<% end_if %>
+
+<% if $Image %>
+    <div class="image">
+        {$Image}
+    </div>
+<% end_if %>
+
+    <div class="form">
+        {$Form}
+    </div>
+
+<% if $AfterFormContent %>
+    <div class="content post">
+        {$AfterFormContent.RAW}
+    </div>
+<% end_if %>
+
 </div>

--- a/tests/ChimpleConfigTest.php
+++ b/tests/ChimpleConfigTest.php
@@ -10,6 +10,7 @@ use SilverStripe\Forms\EmailField;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Security\SecurityToken;
 use SilverStripe\SiteConfig\SiteConfig;
 
@@ -21,8 +22,6 @@ class ChimpleConfigTest extends SapphireTest
 {
 
     protected $usesDatabase = true;
-
-    // protected static $tempDB = true;
 
     public function testConfiguration()
     {
@@ -49,11 +48,7 @@ class ChimpleConfigTest extends SapphireTest
             'IsGlobal' => 1,
             'Heading' => 'My Default Config',
             'MailchimpListId' => 'different_list_id',
-            'ArchiveLink' => 'https://example.com',
-            'UpdateExisting' => 1,
-            'SendWelcome' => 1,
-            'ReplaceInterests' => 1,
-            'DoubleOptIn' => 0 // tests turn off DoubleOptin
+            'ArchiveLink' => 'https://example.com'
         ];
 
         $config = MailchimpConfig::create($record);
@@ -75,8 +70,6 @@ class ChimpleConfigTest extends SapphireTest
         $retrieved_config = MailchimpConfig::getConfig('','', $config->Code);
 
         $this->assertEquals($retrieved_config->ID, $config->ID, "Configs should be the same");
-
-        $this->assertTrue($retrieved_config->DoubleOptIn == 0, "Double Opt In setting should be false");
 
         // test configuration form retrieval
         $form = $config->SubscribeForm(true);
@@ -106,15 +99,10 @@ class ChimpleConfigTest extends SapphireTest
 
         $static_form = MailchimpConfig::get_chimple_subscribe_form($code_value);
 
-        $this->assertTrue( $static_form instanceof Form, "Static form for code {$code_value} was not returned");
+        $this->assertTrue( $static_form instanceof DBHTMLText, "Static form for code {$code_value} was not returned");
 
-        $static_fields = $static_form->Fields();
-
-        $static_code = $static_fields->dataFieldByName('code');
-        $this->assertTrue( $static_code instanceof HiddenField, "'code' field is not present");
-
-        $static_code_value = $static_code->dataValue();
-        $this->assertEquals($static_code_value, $config->Code, "Code value from static form is not the same as config value");
+        $needle = " value=\"{$code_value}\" ";
+        $this->assertTrue( strpos($static_form->forTemplate(), $needle) !== false, "Missing {$code_value} input from form HTML");
 
     }
 }


### PR DESCRIPTION
## Changes

+ Update to handle existing subscribers using patch() rather than silently failing on post when the subscriber already exists
+ Refactor Status handling depending on whether subscriber exists at Mailchimp, use current status returned by MC when updating
+ Failed/Processing status allows reset to New, other status are readonly
+ Refactor tag handling for existing/new subscribers - get current tags to identify which are new/current and removed
+ Put tag removal behind a configuration option as it could be destructive
+ Deprecate ancient UpdateExisting/SendWelcome/ReplaceInterests/DoubleOptIn handling - MC v2 API settings
+ Default email_type to 'html', other option is 'text'

### Tests

+ Update tests to suit

### Documentation

+ Update documentation to suit including overhaul of dev and content author docs, typo fixes

### Misc

+ Update default templates to include before/after content + image if they exist in the configuration
+ Display subscriber web link in administration area, to assist with identifying pending/current members
+ Reduce job interval to avoid default 5 minute waits, to minimise subscription retries
