### PR TITLE
Selectable tags

### DIFF
--- a/src/Controllers/ChimpleController.php
+++ b/src/Controllers/ChimpleController.php
@@ -277,6 +277,7 @@ class ChimpleController extends PageController
                 $tags
             );
         }
+
         if (is_string($description) && $description !== '') {
             $field = $field->setDescription(strip_tags(trim($description)));
         }
@@ -490,14 +491,15 @@ class ChimpleController extends PageController
                 // tagging
                 $selectedTags = [];
                 if(isset($data['SelectedTags'])) {
-                    if(is_array($data['SelectedTags'])) {
+                    if (is_array($data['SelectedTags'])) {
                         // multi select field
                         $selectedTags = $data['SelectedTags'];
-                    } else if(is_string($data['SelectedTags'])) {
+                    } elseif (is_string($data['SelectedTags'])) {
                         // single tag selection
                         $selectedTags[] = $data['SelectedTags'];
                     }
                 }
+
                 $sub->Tags = $this->getSubscriptionTags($mc_config, $selectedTags);
                 $sub_id = $sub->write();
                 if (!$sub_id) {

--- a/src/Controllers/ChimpleController.php
+++ b/src/Controllers/ChimpleController.php
@@ -256,7 +256,7 @@ class ChimpleController extends PageController
         }
 
         $title = strip_tags(trim($title));
-        if($singleSelect) {
+        if ($singleSelect) {
             if ($title === "") {
                 $title = "I am interested in one of the following topics";
             }
@@ -490,7 +490,7 @@ class ChimpleController extends PageController
 
                 // tagging
                 $selectedTags = [];
-                if(isset($data['SelectedTags'])) {
+                if (isset($data['SelectedTags'])) {
                     if (is_array($data['SelectedTags'])) {
                         // multi select field
                         $selectedTags = $data['SelectedTags'];

--- a/src/Controllers/ChimpleController.php
+++ b/src/Controllers/ChimpleController.php
@@ -230,7 +230,6 @@ class ChimpleController extends PageController
      */
     public function getSelectableTagsMeta(array $tags, string $title, ?string $description = null): array
     {
-        $field = [];
         $result['field'] = $this->getSelectableTagsField($tags, $title, $description);
         $result['insertAfter'] = $this->getSelectableTagsFieldPosition();
         return $result;
@@ -252,10 +251,12 @@ class ChimpleController extends PageController
         if($tags == []) {
             return null;
         }
+
         $title = strip_tags(trim($title));
         if($title === "") {
             $title = "I am interested in the following topics";
         }
+
         $field = CheckboxSetField::create(
             'SelectedTags',
             _t(self::class . ".TAGS_USER_SELECT_TITLE", $title),
@@ -264,6 +265,7 @@ class ChimpleController extends PageController
         if(is_string($description)) {
             $field = $field->setDescription(strip_tags(trim($description)));
         }
+
         return $field;
     }
 
@@ -527,8 +529,9 @@ class ChimpleController extends PageController
     /**
      * Return a merged array of tags the user has selected and the default tags from the
      * provided MailchimpConfig instance
+     * @return mixed[]
      */
-    public function getSubscriptionTags(MailchimpConfig $config, array $userSelectedTags = []) {
+    public function getSubscriptionTags(MailchimpConfig $config, array $userSelectedTags = []): array {
         // resulting array of tags
         $subscriptionTags = [];
 

--- a/src/Controllers/ChimpleController.php
+++ b/src/Controllers/ChimpleController.php
@@ -7,6 +7,8 @@ use NSWDPC\Chimple\Forms\XhrSubscribeForm;
 use NSWDPC\Chimple\Exceptions\RequestException;
 use NSWDPC\Chimple\Models\MailchimpConfig;
 use NSWDPC\Chimple\Models\MailchimpSubscriber;
+use SilverStripe\Forms\CheckboxSetField;
+use SilverStripe\Forms\MultiSelectField;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
@@ -22,6 +24,7 @@ use SilverStripe\Control\Email\Email;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\ORM\ValidationResult;
+use Symbiote\MultiValueField\ORM\FieldType\MultiValueField;
 use PageController;
 
 /**
@@ -33,6 +36,8 @@ class ChimpleController extends PageController
     private static string $url_segment = 'mc-subscribe/v1';
 
     private static bool $hide_generic_form = true;
+
+    private static string $selectable_tags_field_position = 'Email';
 
     private static array $allowed_actions = [
         'SubscribeForm',
@@ -218,6 +223,48 @@ class ChimpleController extends PageController
                         ->setAttribute('title', _t(self::class. '.EMAIL', 'Email'))
                         ->setAttribute('required', 'required')
         );
+    }
+
+    /**
+     * Get metadata for the selectable tags field
+     */
+    public function getSelectableTagsMeta(array $tags, string $title, ?string $description = null): array
+    {
+        $field = [];
+        $result['field'] = $this->getSelectableTagsField($tags, $title, $description);
+        $result['insertAfter'] = $this->getSelectableTagsFieldPosition();
+        return $result;
+    }
+
+    /**
+     * Return the field that the selectable tags field should be inserted after
+     */
+    public function getSelectableTagsFieldPosition(): string
+    {
+        return static::config()->get('selectable_tags_field_position') ?? 'Email';
+    }
+
+    /**
+     * Return a MultiSelectField containing all the selectable tags in the provided config
+     */
+    public function getSelectableTagsField(array $tags, string $title, ?string $description = null): ?MultiSelectField
+    {
+        if($tags == []) {
+            return null;
+        }
+        $title = strip_tags(trim($title));
+        if($title === "") {
+            $title = "I am interested in the following topics";
+        }
+        $field = CheckboxSetField::create(
+            'SelectedTags',
+            _t(self::class . ".TAGS_USER_SELECT_TITLE", $title),
+            $tags
+        );
+        if(is_string($description)) {
+            $field = $field->setDescription(strip_tags(trim($description)));
+        }
+        return $field;
     }
 
     /**
@@ -422,7 +469,10 @@ class ChimpleController extends PageController
                 $sub->Email = $data['Email'];
                 $sub->MailchimpListId = $list_id;//list they are subscribing to
                 $sub->Status = MailchimpSubscriber::CHIMPLE_STATUS_NEW;
-                $sub->Tags = $mc_config->Tags;
+                $sub->Tags = $this->getSubscriptionTags(
+                    $mc_config,
+                    isset($data['SelectedTags']) && is_array($data['SelectedTags']) ? $data['SelectedTags'] : []
+                );
                 $sub_id = $sub->write();
                 if (!$sub_id) {
                     throw new RequestException("Bad Gateway", 502);
@@ -472,6 +522,37 @@ class ChimpleController extends PageController
             return $this->redirect($this->Link("?" . $query_string));
         }
 
+    }
+
+    /**
+     * Return a merged array of tags the user has selected and the default tags from the
+     * provided MailchimpConfig instance
+     */
+    public function getSubscriptionTags(MailchimpConfig $config, array $userSelectedTags = []) {
+        // resulting array of tags
+        $subscriptionTags = [];
+
+        // Selectable tags
+        $selectableTags = $config->SelectableTags;
+        if($selectableTags instanceof MultiValueField) {
+            $selectableTagsList = $selectableTags->getValue();
+            if(is_array($selectableTagsList)) {
+                // return all tags allowed in the MailchimpConfig provided
+                // selectable tags are stored in key->value format
+                $subscriptionTags = array_intersect($userSelectedTags, array_keys($selectableTagsList));
+            }
+        }
+
+        // Default tags
+        $tags = $config->Tags;
+        if($tags instanceof MultiValueField) {
+            $configTags = $tags->getValue();
+            if(is_array($configTags)) {
+                $subscriptionTags = array_merge($subscriptionTags, $configTags);
+            }
+        }
+
+        return $subscriptionTags;
     }
 
     /**

--- a/src/Controllers/ChimpleController.php
+++ b/src/Controllers/ChimpleController.php
@@ -9,6 +9,8 @@ use NSWDPC\Chimple\Models\MailchimpConfig;
 use NSWDPC\Chimple\Models\MailchimpSubscriber;
 use SilverStripe\Forms\CheckboxSetField;
 use SilverStripe\Forms\MultiSelectField;
+use SilverStripe\Forms\SingleSelectField;
+use SilverStripe\Forms\OptionsetField;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TextField;
@@ -228,9 +230,9 @@ class ChimpleController extends PageController
     /**
      * Get metadata for the selectable tags field
      */
-    public function getSelectableTagsMeta(array $tags, string $title, ?string $description = null): array
+    public function getSelectableTagsMeta(array $tags, bool $singleSelect, string $title, ?string $description = null): array
     {
-        $result['field'] = $this->getSelectableTagsField($tags, $title, $description);
+        $result['field'] = $this->getSelectableTagsField($tags, $singleSelect, $title, $description);
         $result['insertAfter'] = $this->getSelectableTagsFieldPosition();
         return $result;
     }
@@ -244,25 +246,38 @@ class ChimpleController extends PageController
     }
 
     /**
-     * Return a MultiSelectField containing all the selectable tags in the provided config
+     * Return a MultiSelectField or a SingleSelectField containing all the selectable tags in the provided config
+     * Can return null if no tags are passed
      */
-    public function getSelectableTagsField(array $tags, string $title, ?string $description = null): ?MultiSelectField
+    public function getSelectableTagsField(array $tags, bool $singleSelect, string $title, ?string $description = null): MultiSelectField|SingleSelectField|null
     {
         if ($tags == []) {
             return null;
         }
 
         $title = strip_tags(trim($title));
-        if ($title === "") {
-            $title = "I am interested in the following topics";
-        }
+        if($singleSelect) {
+            if ($title === "") {
+                $title = "I am interested in one of the following topics";
+            }
 
-        $field = CheckboxSetField::create(
-            'SelectedTags',
-            _t(self::class . ".TAGS_USER_SELECT_TITLE", $title),
-            $tags
-        );
-        if (is_string($description)) {
+            $field = OptionsetField::create(
+                'SelectedTags',
+                _t(self::class . ".TAGS_USER_SELECT_SINGLE_TITLE", $title),
+                $tags
+            );
+        } else {
+            if ($title === "") {
+                $title = "I am interested in the following topics";
+            }
+
+            $field = CheckboxSetField::create(
+                'SelectedTags',
+                _t(self::class . ".TAGS_USER_SELECT_TITLE", $title),
+                $tags
+            );
+        }
+        if (is_string($description) && $description !== '') {
             $field = $field->setDescription(strip_tags(trim($description)));
         }
 
@@ -471,10 +486,19 @@ class ChimpleController extends PageController
                 $sub->Email = $data['Email'];
                 $sub->MailchimpListId = $list_id;//list they are subscribing to
                 $sub->Status = MailchimpSubscriber::CHIMPLE_STATUS_NEW;
-                $sub->Tags = $this->getSubscriptionTags(
-                    $mc_config,
-                    isset($data['SelectedTags']) && is_array($data['SelectedTags']) ? $data['SelectedTags'] : []
-                );
+
+                // tagging
+                $selectedTags = [];
+                if(isset($data['SelectedTags'])) {
+                    if(is_array($data['SelectedTags'])) {
+                        // multi select field
+                        $selectedTags = $data['SelectedTags'];
+                    } else if(is_string($data['SelectedTags'])) {
+                        // single tag selection
+                        $selectedTags[] = $data['SelectedTags'];
+                    }
+                }
+                $sub->Tags = $this->getSubscriptionTags($mc_config, $selectedTags);
                 $sub_id = $sub->write();
                 if (!$sub_id) {
                     throw new RequestException("Bad Gateway", 502);

--- a/src/Controllers/ChimpleController.php
+++ b/src/Controllers/ChimpleController.php
@@ -248,12 +248,12 @@ class ChimpleController extends PageController
      */
     public function getSelectableTagsField(array $tags, string $title, ?string $description = null): ?MultiSelectField
     {
-        if($tags == []) {
+        if ($tags == []) {
             return null;
         }
 
         $title = strip_tags(trim($title));
-        if($title === "") {
+        if ($title === "") {
             $title = "I am interested in the following topics";
         }
 
@@ -262,7 +262,7 @@ class ChimpleController extends PageController
             _t(self::class . ".TAGS_USER_SELECT_TITLE", $title),
             $tags
         );
-        if(is_string($description)) {
+        if (is_string($description)) {
             $field = $field->setDescription(strip_tags(trim($description)));
         }
 
@@ -531,15 +531,16 @@ class ChimpleController extends PageController
      * provided MailchimpConfig instance
      * @return mixed[]
      */
-    public function getSubscriptionTags(MailchimpConfig $config, array $userSelectedTags = []): array {
+    public function getSubscriptionTags(MailchimpConfig $config, array $userSelectedTags = []): array
+    {
         // resulting array of tags
         $subscriptionTags = [];
 
         // Selectable tags
         $selectableTags = $config->SelectableTags;
-        if($selectableTags instanceof MultiValueField) {
+        if ($selectableTags instanceof MultiValueField) {
             $selectableTagsList = $selectableTags->getValue();
-            if(is_array($selectableTagsList)) {
+            if (is_array($selectableTagsList)) {
                 // return all tags allowed in the MailchimpConfig provided
                 // selectable tags are stored in key->value format
                 $subscriptionTags = array_intersect($userSelectedTags, array_keys($selectableTagsList));
@@ -548,9 +549,9 @@ class ChimpleController extends PageController
 
         // Default tags
         $tags = $config->Tags;
-        if($tags instanceof MultiValueField) {
+        if ($tags instanceof MultiValueField) {
             $configTags = $tags->getValue();
-            if(is_array($configTags)) {
+            if (is_array($configTags)) {
                 $subscriptionTags = array_merge($subscriptionTags, $configTags);
             }
         }

--- a/src/Models/MailchimpConfig.php
+++ b/src/Models/MailchimpConfig.php
@@ -520,7 +520,7 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
             // only one allowed?
             $singleSelect = $this->SelectableTagsOneOnly == 1;
             // get the selectable tags field and other data
-            $selectableTagsMeta = $controller->getSelectableTagsMeta($this->getSelectableTagsList(), $singleSelect, $this->SelectableTagsTitle ?? ''); 
+            $selectableTagsMeta = $controller->getSelectableTagsMeta($this->getSelectableTagsList(), $singleSelect, $this->SelectableTagsTitle ?? '');
             $insertTagsAfter = isset($selectableTagsMeta['insertAfter']) && is_string($selectableTagsMeta['insertAfter']) ? $selectableTagsMeta['insertAfter'] : 'Email';
             if (isset($selectableTagsMeta['field']) && $selectableTagsMeta['field'] instanceof MultiSelectField || $selectableTagsMeta['field'] instanceof SingleSelectField) {
                 $fields->insertAfter($insertTagsAfter, $selectableTagsMeta['field']);

--- a/src/Models/MailchimpConfig.php
+++ b/src/Models/MailchimpConfig.php
@@ -45,6 +45,9 @@ use Symbiote\MultiValueField\ORM\FieldType\MultiValueField;
  * @property bool $UseXHR
  * @property ?string $BeforeFormContent
  * @property ?string $AfterFormContent
+ * @property mixed $SelectableTags
+ * @property bool $SelectableTagsEnabled
+ * @property ?string $SelectableTagsTitle
  */
 class MailchimpConfig extends DataObject implements TemplateGlobalProvider, PermissionProvider
 {
@@ -527,6 +530,7 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
                 return $tags;
             }
         }
+
         return [];
     }
 

--- a/src/Models/MailchimpConfig.php
+++ b/src/Models/MailchimpConfig.php
@@ -331,7 +331,8 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
 
         $fields->removeByName(['Tags','SelectableTags','SelectableTagsEnabled','SelectableTagsTitle']);
         $fields->addFieldsToTab(
-            'Root.Tagging', [
+            'Root.Tagging',
+            [
                 MultiValueTextField::create(
                     'Tags',
                     _t(
@@ -504,7 +505,7 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
             // add the selectable tags field
             $selectableTagsMeta = $controller->getSelectableTagsMeta($this->getSelectableTagsList(), $this->SelectableTagsTitle ?? '');
             $insertTagsAfter = isset($selectableTagsMeta['insertAfter']) && is_string($selectableTagsMeta['insertAfter']) ? $selectableTagsMeta['insertAfter'] : 'Email';
-            if(isset($selectableTagsMeta['field']) && $selectableTagsMeta['field'] instanceof MultiSelectField) {
+            if (isset($selectableTagsMeta['field']) && $selectableTagsMeta['field'] instanceof MultiSelectField) {
                 $fields->insertAfter($insertTagsAfter, $selectableTagsMeta['field']);
             }
 
@@ -524,9 +525,9 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
      */
     public function getSelectableTagsList(): array
     {
-        if($this->SelectableTagsEnabled && (($selectableTags = $this->SelectableTags) instanceof MultiValueField)) {
+        if ($this->SelectableTagsEnabled && (($selectableTags = $this->SelectableTags) instanceof MultiValueField)) {
             $tags = $selectableTags->getValue();
-            if(is_array($tags)) {
+            if (is_array($tags)) {
                 return $tags;
             }
         }

--- a/src/Models/MailchimpConfig.php
+++ b/src/Models/MailchimpConfig.php
@@ -49,6 +49,7 @@ use Symbiote\MultiValueField\ORM\FieldType\MultiValueField;
  * @property mixed $SelectableTags
  * @property bool $SelectableTagsEnabled
  * @property ?string $SelectableTagsTitle
+ * @property bool $SelectableTagsOneOnly
  */
 class MailchimpConfig extends DataObject implements TemplateGlobalProvider, PermissionProvider
 {

--- a/src/Models/MailchimpConfig.php
+++ b/src/Models/MailchimpConfig.php
@@ -11,8 +11,10 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\LiteralField;
+use SilverStripe\Forms\MultiSelectField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
@@ -21,7 +23,9 @@ use SilverStripe\Security\PermissionProvider;
 use SilverStripe\Security\Permission;
 use SilverStripe\SiteConfig\SiteConfig;
 use SilverStripe\View\TemplateGlobalProvider;
+use Symbiote\MultiValueField\Fields\KeyValueField;
 use Symbiote\MultiValueField\Fields\MultiValueTextField;
+use Symbiote\MultiValueField\ORM\FieldType\MultiValueField;
 
 /**
  * Configure mailchimp subscriptions - this is linked to {@link Site} for the global form
@@ -78,8 +82,10 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
         'SendWelcome' => 'Boolean',// @deprecated
         'ReplaceInterests' => 'Boolean',// @deprecated
         'DoubleOptIn' => 'Boolean',// @deprecated
-        // for storing tags to submit with subscriber
-        'Tags' => 'MultiValueField',
+        'Tags' => 'MultiValueField',// for storing tags to submit with subscriber
+        'SelectableTags' => 'MultiValueField',// optional selectable tags
+        'SelectableTagsEnabled' => 'Boolean', // whether the user can select the tags in SelectableTags,
+        'SelectableTagsTitle' => 'Varchar(255)', // title for the tag selection field
         'UseXHR' => 'Boolean',// whether to submit without redirect
         'BeforeFormContent' => 'HTMLText',
         'AfterFormContent' => 'HTMLText'
@@ -112,7 +118,8 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
         'ReplaceInterests' => 0,// @deprecated
         'DoubleOptIn' => 1,// @deprecated
         'IsGlobal' => 0,
-        'UseXHR' => 1
+        'UseXHR' => 1,
+        'SelectableTagsTitle' => "I am interested in the following topics"
     ];
 
     public function TitleCode(): string
@@ -319,15 +326,60 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
             );
         }
 
-        $fields->addFieldToTab(
-            'Root.Main',
-            MultiValueTextField::create(
-                'Tags',
-                _t(
-                    self::class . '.TAGS_FOR_SUBSCRIPTIONS',
-                    'Tags assigned to subscribers'
+        $fields->removeByName(['Tags','SelectableTags','SelectableTagsEnabled','SelectableTagsTitle']);
+        $fields->addFieldsToTab(
+            'Root.Tagging', [
+                MultiValueTextField::create(
+                    'Tags',
+                    _t(
+                        self::class . '.TAGS_FOR_SUBSCRIPTIONS',
+                        'Tags assigned to subscribers'
+                    )
+                )->setRightTitle(
+                    _t(
+                        self::class . '.TAGS_FOR_SUBSCRIPTIONS_HELPTEXT',
+                        'These tags will be assigned to susbcribers who have subscribed via forms using this configuration'
+                    )
+                ),
+                CompositeField::create(
+                    KeyValueField::create(
+                        'SelectableTags',
+                        _t(
+                            self::class . '.TAGS_FOR_SUBSCRIBERS_TO_SELECT',
+                            'Enter tag names and descriptions'
+                        )
+                    )->setRightTitle(
+                        _t(
+                            self::class . '.TAGS_FOR_SUBSCRIBERS_TO_SELECT_HELPTEXT',
+                            'Enter the Mailchimp tag name on the left and the value that will be seen by a subscriber on the right'
+                        )
+                    ),
+                    CheckboxField::create(
+                        'SelectableTagsEnabled',
+                        _t(
+                            self::class . '.TAGS_FOR_SUBSCRIBERS_ENABLED',
+                            'Allow the tags listed above to be shown in subscription forms'
+                        )
+                    )->setRightTitle(
+                        _t(
+                            self::class . '.TAGS_FOR_SUBSCRIBERS_ENABLED_HELPTEXT',
+                            'Allows toggling visibility of selectable tags.'
+                        )
+                    ),
+                    TextField::create(
+                        'SelectableTagsTitle',
+                        _t(
+                            self::class . '.TAGS_FOR_SUBSCRIBERS_TITLE',
+                            'The title that will prompt subscribers to select the tags'
+                        )
+                    )
+                )->setTitle(
+                    _t(
+                        self::class . '.TAGS_FOR_SUBSCRIBERS_GROUP_TITLE',
+                        'Tags that can be selected by subscribers'
+                    )
                 )
-            )
+            ]
         );
 
         $fields->addFieldToTab(
@@ -433,24 +485,49 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
 
         // ensure the form has a unique name per code
         $formNameSuffix = ($this->Code ?? '');
-        $form = Injector::inst()->create(ChimpleController::class)
-            ->setFormNameSuffix($formNameSuffix)
-            ->getSubscriptionForm($use_xhr);
+        $controller = Injector::inst()->create(ChimpleController::class);
+        $form = $controller->setFormNameSuffix($formNameSuffix)->getSubscriptionForm($use_xhr);
         // to return a form, there must be one and the Code must exist
         if ($form && $this->Code) {
             // apply the code for this config to the form
+            $fields = $form->Fields();
             $code_field = HiddenField::create('code', 'code', $this->Code);
             $code_field->setForm($form);
-            $form->Fields()->push($code_field);
+            $fields->push($code_field);
             if ($this->Heading) {
                 $form->setLegend($this->Heading);
             }
 
+            // add the selectable tags field
+            $selectableTagsMeta = $controller->getSelectableTagsMeta($this->getSelectableTagsList(), $this->SelectableTagsTitle ?? '');
+            $insertTagsAfter = isset($selectableTagsMeta['insertAfter']) && is_string($selectableTagsMeta['insertAfter']) ? $selectableTagsMeta['insertAfter'] : 'Email';
+            if(isset($selectableTagsMeta['field']) && $selectableTagsMeta['field'] instanceof MultiSelectField) {
+                $fields->insertAfter($insertTagsAfter, $selectableTagsMeta['field']);
+            }
+
             $form->addExtraClass('form-subscribe');
+
+            // allow extensions to update the configured field
+            $form->extend('updateConfiguredChimpleSubscribeForm');
+
             return $form;
         }
 
         return null;
+    }
+
+    /**
+     * Return an array in key=>value format of all tags available for selection
+     */
+    public function getSelectableTagsList(): array
+    {
+        if($this->SelectableTagsEnabled && (($selectableTags = $this->SelectableTags) instanceof MultiValueField)) {
+            $tags = $selectableTags->getValue();
+            if(is_array($tags)) {
+                return $tags;
+            }
+        }
+        return [];
     }
 
     /**

--- a/src/Models/MailchimpConfig.php
+++ b/src/Models/MailchimpConfig.php
@@ -12,6 +12,7 @@ use SilverStripe\Forms\Form;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\MultiSelectField;
+use SilverStripe\Forms\SingleSelectField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\CompositeField;
@@ -88,6 +89,7 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
         'Tags' => 'MultiValueField',// for storing tags to submit with subscriber
         'SelectableTags' => 'MultiValueField',// optional selectable tags
         'SelectableTagsEnabled' => 'Boolean', // whether the user can select the tags in SelectableTags,
+        'SelectableTagsOneOnly' => 'Boolean', // whether the user can only select one of the tags
         'SelectableTagsTitle' => 'Varchar(255)', // title for the tag selection field
         'UseXHR' => 'Boolean',// whether to submit without redirect
         'BeforeFormContent' => 'HTMLText',
@@ -329,7 +331,7 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
             );
         }
 
-        $fields->removeByName(['Tags','SelectableTags','SelectableTagsEnabled','SelectableTagsTitle']);
+        $fields->removeByName(['Tags','SelectableTags','SelectableTagsEnabled','SelectableTagsOneOnly','SelectableTagsTitle']);
         $fields->addFieldsToTab(
             'Root.Tagging',
             [
@@ -368,6 +370,18 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
                         _t(
                             self::class . '.TAGS_FOR_SUBSCRIBERS_ENABLED_HELPTEXT',
                             'Allows toggling visibility of selectable tags.'
+                        )
+                    ),
+                    CheckboxField::create(
+                        'SelectableTagsOneOnly',
+                        _t(
+                            self::class . '.TAGS_FOR_SUBSCRIBERS_ONE_ONLY',
+                            'Subscriber can select one tag only'
+                        )
+                    )->setRightTitle(
+                        _t(
+                            self::class . '.TAGS_FOR_SUBSCRIBERS_ONE_ONLY_HELPTEXT',
+                            'Adds a single-selection field instead of a multi-selection field.'
                         )
                     ),
                     TextField::create(
@@ -502,10 +516,12 @@ class MailchimpConfig extends DataObject implements TemplateGlobalProvider, Perm
                 $form->setLegend($this->Heading);
             }
 
-            // add the selectable tags field
-            $selectableTagsMeta = $controller->getSelectableTagsMeta($this->getSelectableTagsList(), $this->SelectableTagsTitle ?? '');
+            // only one allowed?
+            $singleSelect = $this->SelectableTagsOneOnly == 1;
+            // get the selectable tags field and other data
+            $selectableTagsMeta = $controller->getSelectableTagsMeta($this->getSelectableTagsList(), $singleSelect, $this->SelectableTagsTitle ?? ''); 
             $insertTagsAfter = isset($selectableTagsMeta['insertAfter']) && is_string($selectableTagsMeta['insertAfter']) ? $selectableTagsMeta['insertAfter'] : 'Email';
-            if (isset($selectableTagsMeta['field']) && $selectableTagsMeta['field'] instanceof MultiSelectField) {
+            if (isset($selectableTagsMeta['field']) && $selectableTagsMeta['field'] instanceof MultiSelectField || $selectableTagsMeta['field'] instanceof SingleSelectField) {
                 $fields->insertAfter($insertTagsAfter, $selectableTagsMeta['field']);
             }
 

--- a/src/Models/MailchimpSubscriber.php
+++ b/src/Models/MailchimpSubscriber.php
@@ -310,6 +310,7 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
             Logger::log("Failed to get current subscriber tags: {$exception->getMessage()}", "NOTICE");
             $tags = [];
         }
+
         $tag_field_description = "";
         if ($tags !== []) {
             $tag_field_description = _t(

--- a/src/Models/MailchimpSubscriber.php
+++ b/src/Models/MailchimpSubscriber.php
@@ -304,7 +304,12 @@ class MailchimpSubscriber extends DataObject implements PermissionProvider
             );
         }
 
-        $tags = $this->getCurrentSubscriberTags();
+        try {
+            $tags = $this->getCurrentSubscriberTags();
+        } catch (\Exception $exception) {
+            Logger::log("Failed to get current subscriber tags: {$exception->getMessage()}", "NOTICE");
+            $tags = [];
+        }
         $tag_field_description = "";
         if ($tags !== []) {
             $tag_field_description = _t(

--- a/tests/ChimpleFunctionalTest.php
+++ b/tests/ChimpleFunctionalTest.php
@@ -117,4 +117,49 @@ class ChimpleFunctionalTest extends FunctionalTest
         });
 
     }
+
+
+    public function testFormSubmissionWithTags(): void
+    {
+
+        $config = MailchimpConfig::get()->filter(['Code' => $this->test_form_code])->first();
+
+        // add selectable tags to config
+        $config->SelectableTagsEnabled = 1;
+        $config->SelectableTagsOneOnly = 0;
+        $config->SelectableTagsTitle = 'Select your interests';
+        $config->SelectableTags = ["tag1" => "Tag 1", "tag2" => "Tag 2" ];
+        $config->write();
+
+        $this->useTestTheme(__DIR__, 'chimpletest', function (): void {
+
+            // request default route
+            $url = "/mc-subscribe/v1/";
+            $page = $this->get($url);
+
+            $formId = "TestSubscribeForm_SubscribeForm_{$this->test_form_code}";
+            $email = 'functionaltester@example.org';
+            $response = $this->submitForm(
+                $formId,
+                null,
+                [
+                    'Name' => 'Functional Tester',
+                    'Email' => $email,
+                    'SelectedTags[tag1]' => 'tag1',
+                    'SelectedTags[tag2]' => 'tag2',
+                ]
+            );
+
+            $subscriber = MailchimpSubscriber::get()->filter([
+                'Email' => $email,
+                'Status' => MailchimpSubscriber::CHIMPLE_STATUS_NEW
+            ])->first();
+
+            $this->assertTrue($subscriber && $subscriber->exists());
+
+            $tags = $subscriber->Tags->getValue();
+            $this->assertEquals(['tag1','tag2'], array_values($tags));
+
+        });
+    }
 }


### PR DESCRIPTION
## Changes

+ Add a field to configuration set a list of of key->value pairs being selectable tags
+ Selectable tags are displayed in a subscription form via  a MultiSelectField (CheckboxSetField  by default)
+ Add a field to allow this to be toggled on and off in a subscription form
+ Add a field to allow the title for selectable tags to be specified
+ When saving a subscriber merge the default tags (if any) with the allowed selected tags (if any)

(Was #32)